### PR TITLE
Limit the budget category graph length to 100%

### DIFF
--- a/src/components/CategoryGraph.svelte
+++ b/src/components/CategoryGraph.svelte
@@ -20,6 +20,8 @@ const calculageWidth = (remaining, total) => {
     return 0;
   } else if (total === 0) {
     return (remaining > 0) ? 100 : 0;
+  } else if (remaining > total) {
+    return 100;
   }
   return (remaining / total) * 100;
 }


### PR DESCRIPTION
### Fixed
- Limit the budget category graph length to 100%