### PR TITLE
Release 2025.04.23.2 - Switch to using CRUDL-style operations for accounts data

### DIFF
--- a/src/data/accounts.js
+++ b/src/data/accounts.js
@@ -21,6 +21,10 @@ export const getAccountFrom = (uuid, list) => {
   return list.find(item => item.uuid === uuid) || {}
 }
 
+export const listAccounts = () => {
+  return getListFromStorage(ACCOUNTS)
+}
+
 export const loadAccounts = () => {
   accounts.set(getListFromStorage(ACCOUNTS))
 }

--- a/src/data/accounts.js
+++ b/src/data/accounts.js
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 const ACCOUNTS = 'accounts'
 
-export const accounts = writable([])
+const accounts = writable([])
 
 export const createAccount = name => {
   const newAccount = {
@@ -22,7 +22,7 @@ export const getAccount = (uuid) => {
   return getAccountFrom(uuid, accounts)
 }
 
-export const getAccountFrom = (uuid, list) => {
+const getAccountFrom = (uuid, list) => {
   return list.find(item => item.uuid === uuid) || {}
 }
 

--- a/src/data/accounts.js
+++ b/src/data/accounts.js
@@ -17,6 +17,11 @@ export const createAccount = name => {
   return newAccount
 }
 
+export const getAccount = (uuid) => {
+  const accounts = listAccounts()
+  return getAccountFrom(uuid, accounts)
+}
+
 export const getAccountFrom = (uuid, list) => {
   return list.find(item => item.uuid === uuid) || {}
 }

--- a/src/views/AccountView.svelte
+++ b/src/views/AccountView.svelte
@@ -1,5 +1,5 @@
 <script>
-import { accounts, updateAccount } from '../data/accounts'
+import { getAccount, updateAccount } from '../data/accounts'
 import { getTransactionsForAccount } from '../data/transactions'
 import Button from '../components/Button.svelte'
 import ButtonRow from '../components/ButtonRow.svelte'
@@ -10,7 +10,7 @@ import { faEdit, faListUl } from '@fortawesome/free-solid-svg-icons'
 export let params = {} // URL parameters provided by router
 
 $: uuid = params.uuid || ''
-$: account = $accounts.find(account => account.uuid === uuid) || {}
+$: account = getAccount(uuid)
 $: transactions = getTransactionsForAccount(uuid)
 
 const renameAccount = () => {

--- a/src/views/Accounts.svelte
+++ b/src/views/Accounts.svelte
@@ -1,13 +1,20 @@
 <script>
-import { accounts } from '../data/accounts'
+import { listAccounts } from '../data/accounts'
 import Button from '../components/Button.svelte'
 import ButtonRow from '../components/ButtonRow.svelte'
 import { faHome } from '@fortawesome/free-solid-svg-icons'
+import { onMount } from 'svelte'
+
+let accounts = []
+
+onMount(() => {
+  accounts = listAccounts()
+})
 </script>
 
 <h2>Accounts</h2>
 
-{#each $accounts as { name, uuid }}
+{#each accounts as { name, uuid }}
   <p>
     <a href="#/account/{ uuid }" class="btn btn-outline-secondary">{ name }</a>
   </p>

--- a/src/views/ExpenseAccount.svelte
+++ b/src/views/ExpenseAccount.svelte
@@ -2,21 +2,28 @@
 import AccountSelector from '../components/AccountSelector.svelte'
 import Button from '../components/Button.svelte'
 import ButtonRow from '../components/ButtonRow.svelte'
-import { accounts } from '../data/accounts'
+import { listAccounts } from '../data/accounts'
 import { updatePendingTransaction } from '../data/transactions'
 import { faHome } from '@fortawesome/free-solid-svg-icons'
+import { onMount } from 'svelte'
 import { push } from 'svelte-spa-router'
+
+let accounts = []
 
 function setAccount(event) {
   let accountUuid = event.detail
   updatePendingTransaction({ accountUuid })
   push(`/expense/amount/`)
 }
+
+onMount(() => {
+  accounts = listAccounts()
+})
 </script>
 
 <h2>Paid using</h2>
 
-<AccountSelector accounts={$accounts} on:select={setAccount} />
+<AccountSelector accounts={accounts} on:select={setAccount} />
 
 <ButtonRow>
   <Button icon={faHome} name="budget" url="#/budget" left />

--- a/src/views/ExpenseReview.svelte
+++ b/src/views/ExpenseReview.svelte
@@ -2,7 +2,7 @@
 import Button from '../components/Button.svelte'
 import ButtonRow from '../components/ButtonRow.svelte'
 import CategoryTags from '../components/CategoryTags.svelte'
-import { accounts, getAccountFrom } from '../data/accounts'
+import { getAccount } from '../data/accounts'
 import { categories, getCategoryFrom } from '../data/categories'
 import { savePendingTransaction, transactionInProgress, updatePendingTransaction } from '../data/transactions'
 import { faHome } from '@fortawesome/free-solid-svg-icons'
@@ -12,7 +12,7 @@ import { push } from 'svelte-spa-router'
 
 $: transaction = $transactionInProgress
 $: transactionNote = transaction.note || ''
-$: account = getAccountFrom(transaction.accountUuid, $accounts)
+$: account = getAccount(transaction.accountUuid)
 $: accountName = account.name || ''
 $: amountTotal = transaction.amountTotal || 0
 


### PR DESCRIPTION
### Changed (non-breaking)
- Switch to using CRUDL-style operations for accounts data
  * This is to prepare for an anticipated change to a different data storage mechanism (localStorage to PouchDB)